### PR TITLE
add feature for fixed height

### DIFF
--- a/lib/open-files-pane-view.js
+++ b/lib/open-files-pane-view.js
@@ -42,6 +42,7 @@ export default class OpenFilesPaneView {
 		let panelHeaderFileEntry = document.createElement('li')
 		panelHeaderFileEntry.classList.add('list-nested-item', 'expanded')
 		this.entriesList = document.createElement('ol')
+
 		this.entriesList.classList.add('list-tree')
 		let header = document.createElement('div')
     header.classList.add('open-files-title')
@@ -60,6 +61,28 @@ export default class OpenFilesPaneView {
 				header.style.paddingTop = '5px'
 				header.style.marginTop = '0px'
 				header.style.paddingBottom = '0px'
+			}
+		})
+
+		atom.config.observe('open-files.scrollable', scrollable => {
+			if (scrollable) {
+				let scroller_height = atom.config.get('open-files.height')
+				this.entriesList.style.height = scroller_height.toString().concat("vh")
+				this.entriesList.style.overflowY = 'scroll'
+			} else {
+				this.entriesList.style.height = 'auto'
+				this.entriesList.style.overflowY = 'auto'
+			}
+		})
+
+		atom.config.observe('open-files.height', scroller_height => {
+			let scrollable = atom.config.get('open-files.scrollable')
+			if (scrollable) {
+				this.entriesList.style.height = scroller_height.toString().concat("vh")
+				this.entriesList.style.overflowY = 'scroll'
+			} else {
+				this.entriesList.style.height = 'auto'
+				this.entriesList.style.overflowY = 'auto'
 			}
 		})
 

--- a/lib/open-files.js
+++ b/lib/open-files.js
@@ -14,6 +14,18 @@ export default {
 			type: 'boolean',
 			default: true
 		},
+		scrollable: {
+			title: 'Fixed Height',
+			description: 'If selected, the \'Open Files\' panel height is fixed to \'Height\'% of the window',
+			type: 'boolean',
+			default: false
+		},
+		height: {
+			title: 'Height',
+			description: 'Percentage of height used by the \'Open Files\' panel if fixed height is selected',
+			type: 'integer',
+			default: 20
+		},
 		sortOrder: {
 			title: 'Sort Order',
 			description: 'Indicate the order of the criteria for the sorting of the open files list, separated by commas. Options: base (filename), ext (extension), dir (directory)',


### PR DESCRIPTION
This adds the option to set the open files pane to a user defined percentage of the windows height. If the amount of files listed does not fit into the height, the open windows pane becomes scrollable. This functionality is handy when working on lots of open files while still wanting to browse the regular file tree without a lot of scrolling

![open-files-fixed-height](https://user-images.githubusercontent.com/28986714/98296473-43adc200-1fb3-11eb-99b2-73b9d25f0c5c.png)
